### PR TITLE
fix: add IDs to sections for improved navigation and accessibility

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -15,7 +15,7 @@ const { lang }: Props = Astro.props;
 const t = lang === 'es' ? es.footer : en.footer;
 ---
 <CloudStart viewBox="0 0 1441.631 72.493" class="w-full h-auto opacity-100 my-[-1px]"/>
-<div class="bg-cloud w-full flex flex-col pt-16 gap-16">
+<div class="bg-cloud w-full flex flex-col pt-16 gap-16" id="sponsors">
   <p class="font-bold text-[48px] leading-[100%] text-center text-yellow-title font-display-title text-border">{t.title}</p> 
   <div class="flex flex-row justify-center gap-x-8 pb-16">
     <GdgLogo class="w-auto" />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -45,8 +45,8 @@ const t = lang === 'es' ? es.header : en.header;
     <nav class="flex flex-col space-y-2">
       <a href="#hero" class="text-white text-sm">{t.home}</a>
       <a href="#about" class="text-white text-sm">{t.about}</a>
-      <a href="#participants" class="text-white text-sm">{t.participants}</a>
-      <a href="#organizers" class="text-white text-sm">{t.organizers}</a>
+      <!-- <a href="#participants" class="text-white text-sm">{t.participants}</a> -->
+      <!-- <a href="#organizers" class="text-white text-sm">{t.organizers}</a> -->
       <a href="#sponsors" class="text-white text-sm">{t.sponsors}</a>
       <!-- <a href="https://events.gdg.com.bo/wgj-bolivia-2025" target="_blank"
          class="bg-secondary text-black font-semibold px-4 py-2 rounded text-sm mt-2">

--- a/src/components/Info.astro
+++ b/src/components/Info.astro
@@ -18,7 +18,7 @@ const t = lang === "es" ? es.info : en.info;
   viewBox="0 0 1441.631 72.493"
   class="w-full h-auto opacity-100 my-[-1px]"
 />
-<section class="bg-cloud text-center py-16 px-4">
+<section class="bg-cloud text-center py-16 px-4" id="about">
   <div class="max-w-4xl mx-auto">
     <h2
       class="font-bold text-[48px] leading-[100%] text-center text-yellow-title font-display-title text-border"

--- a/src/components/Register.astro
+++ b/src/components/Register.astro
@@ -17,7 +17,7 @@ export interface Props {
 const { lang }: Props = Astro.props;
 const t = lang === "es" ? es.register : en.register;
 ---
-<section class="bg-primary py-16">
+<section class="bg-primary py-16" id="hero">
   <div class="w-full flex flex-col items-end">
     <StartRight  class="my-[-1px] mr-35"/>
     <CloudRight  class="opacity-100 my-[-1px]"/>


### PR DESCRIPTION
This pull request mainly adds section IDs to various components to improve navigation and updates the header navigation links accordingly. The most important changes are the addition of IDs to key sections and the adjustment of navigation links in the header.

**Navigation improvements:**

* Added `id="hero"` to the main registration section in `Register.astro` to enable direct navigation to the hero section.
* Added `id="about"` to the information section in `Info.astro` for direct access via anchor links.
* Added `id="sponsors"` to the sponsors section in `Footer.astro` for navigation purposes.

**Header navigation updates:**

* Updated `Header.astro` to link directly to the new section IDs and commented out the "participants" and "organizers" links, leaving only relevant navigation options visible.