### PR TITLE
fix: update action text in Register component for clarity

### DIFF
--- a/src/components/Register.astro
+++ b/src/components/Register.astro
@@ -47,11 +47,11 @@ const t = lang === "es" ? es.register : en.register;
           </div>
         </div>
         <br />
-        <!-- <div>
+        <div>
           <a href="https://events.gdg.com.bo/wgj-bolivia-2025" target="_blank"
              class="bg-secondary text-black font-bold font-display-text px-4 py-2 rounded hover:scale-105 transition text-xs md:text-sm">
             {t.action}
-          </a> -->
+          </a>
         </div>
       </div>
     </div>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -13,7 +13,7 @@
       "description2" : "Live the Game Jam experience.",
       "date" : "August 8 to 10",
       "eventType" : "Online event",
-      "action" : "Register here"
+      "action" : "Souvenirs"
     },
     "info": {
       "title": "What is the Women Game Jam?",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -13,7 +13,7 @@
       "description2" : "Vive la experiencia de la Game Jam.",
       "date" : "8 al 10 Agosto",
       "eventType" : "Evento Online",
-      "action" : "Registrate aquí"
+      "action" : "Souvenirs"
     },
     "info": {
         "title": "¿Qué es el Women Game Jam?",


### PR DESCRIPTION
This pull request updates the registration section of the site to promote "Souvenirs" instead of registration, reflecting a shift in the call-to-action across both English and Spanish versions. The main changes include updating the action text in the locale files and displaying the corresponding button on the registration component.

Localization updates:

* Changed the `action` text from "Register here" to "Souvenirs" in the English locale file `en.json`.
* Changed the `action` text from "Registrate aquí" to "Souvenirs" in the Spanish locale file `es.json`.

Component update:

* Un-commented and displayed the action button in the `Register.astro` component, ensuring the new "Souvenirs" text appears as the call-to-action.